### PR TITLE
Update Flake and create Flake package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ things. So I made one.
 Building
 ========
 
-Running `nix-shell --command 'cargo build --release'` should work. The
+Running `nix develop --command cargo build --release` should work. The
 executable will then be in `./target/release/scromble`. Please file an
 issue if that doesn't work!
 
 If you would like to use the AVX2 backend for XChaCha20, build with
-`nix-shell --command 'RUSTFLAGS="-Ctarget-cpu=haswell
--Ctarget-feature=+sse2" cargo build --release'` instead. Everything
-else should be the same. The fastest results I've seen are expected
-with `RUSTFLAGS="-Ctarget-cpu=native"`.
+`RUSTFLAGS="-Ctarget-cpu=haswell -Ctarget-feature=+sse2" nix develop
+--command cargo build --release` instead. Everything else should be the
+same. The fastest results I've seen are expected with
+`RUSTFLAGS="-Ctarget-cpu=native"`.
 
 NOTE FOR WINDOWS USERS
 ======================

--- a/flake.lock
+++ b/flake.lock
@@ -15,21 +15,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1733261153,
@@ -46,46 +31,10 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1665296151,
-        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1676514619,
-        "narHash": "sha256-/zVNJdETe/7txiP8NVjAjrAPudLIvjKJWgztuTi75Qw=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "3bab7ae4a80de02377005d611dc4b0a13082aa7c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -32,16 +32,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "lastModified": 1733261153,
+        "narHash": "sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "rev": "b681065d0919f7eb5309a93cea2cfa84dec9aa88",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-21.11",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A devShell example";
 
   inputs = {
-    nixpkgs.url      = github:nixos/nixpkgs/nixos-21.11;
+    nixpkgs.url      = github:nixos/nixpkgs/nixos-24.11;
     flake-utils.url  = github:numtide/flake-utils;
     rust-overlay.url = github:oxalica/rust-overlay;
   };
@@ -16,7 +16,7 @@
         };
       in
       with pkgs;
-      {
+      rec {
         devShell = mkShell {
           buildInputs = [
             openssl
@@ -26,6 +26,13 @@
 
           RUST_BACKTRACE="full";
         };
+        packages.scromble = rustPlatform.buildRustPackage rec {
+          name = "scromble-${version}";
+          version = if (self ? rev) then self.rev else "dirty";
+          src = self;
+          cargoLock.lockFile = ./Cargo.lock;
+        };
+        packages.default = packages.scromble;
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,25 +4,19 @@
   inputs = {
     nixpkgs.url      = github:nixos/nixpkgs/nixos-24.11;
     flake-utils.url  = github:numtide/flake-utils;
-    rust-overlay.url = github:oxalica/rust-overlay;
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }:
+  outputs = { self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
-          inherit system overlays;
+          inherit system;
         };
       in
       with pkgs;
       rec {
         devShell = mkShell {
-          buildInputs = [
-            openssl
-            pkgconfig
-            rust-bin.stable.latest.default
-          ];
+          buildInputs = [ cargo ];
 
           RUST_BACKTRACE="full";
         };


### PR DESCRIPTION
Rust is in Nixpkgs 24.11, so an overlay for Rust is not needed. Openssl and Pkgconfig aren't needed to build scromble.

The documentation for building scromble didn't work. These changes fix the devShell derivation and documentation.

Adding a derivation to the Flake outputs allows scromble to be used from `nix shell github:docprofsky/scromble/flake-update#scromble`. Setting `packages.default` in the Flake outputs lets `nix shell github:docprofsky/scromble/flake-update` provide scromble.